### PR TITLE
chore: Update guardians-sdk to v1.10.1 and improve certificate issuance process

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/biter777/countries v1.7.5
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/ethereum/go-ethereum v1.14.8
-	github.com/galactica-corp/guardians-sdk v1.9.0
+	github.com/galactica-corp/guardians-sdk v1.10.1
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/iden3/go-iden3-crypto v0.0.16
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/galactica-corp/guardians-sdk v1.9.0 h1:069gj1u/hUqCHp8qcwbLv/RRKYzr93V+198U2k/o33E=
-github.com/galactica-corp/guardians-sdk v1.9.0/go.mod h1:7PZ7QwUCGj3YEdjAWfyqXrXZaPDdMvOzDiaQTl+9mzo=
+github.com/galactica-corp/guardians-sdk v1.10.1 h1:hdzulQIeav5Y37PCLaRXTnaUG1S4aIcLGNo69l/t/84=
+github.com/galactica-corp/guardians-sdk v1.10.1/go.mod h1:7PZ7QwUCGj3YEdjAWfyqXrXZaPDdMvOzDiaQTl+9mzo=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -119,6 +119,15 @@ func (h *Handlers) GenerateCert(c echo.Context) error {
 		Info("cert created")
 
 	callback := func(issuedCert zkcertificate.IssuedCertificate[zkcertificate.KYCContent], err error) {
+		if err != nil {
+			log.WithError(err).Error("cert issuance")
+
+			if err := deleteUserDataFromDB(h.inMem, req.UserID); err != nil {
+				log.WithError(err).Error("clean up db after cert issuance")
+			}
+			return
+		}
+
 		log.WithField("holderCommitment", hc).
 			WithField("userID", req.UserID).
 			Info("certificate issued")

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -41,6 +41,12 @@ func readCertFromDB(db *badger.DB, userID UserID) (string, error) {
 	return string(certData), nil
 }
 
+func deleteUserDataFromDB(db *badger.DB, userID UserID) error {
+	return db.Update(func(txn *badger.Txn) error {
+		return txn.Delete([]byte(userID))
+	})
+}
+
 func stripToSix(hash zkcertificate.Hash) string {
 	s := hash.String()
 	if len(s) > 6 {

--- a/internal/zkcert/generator.go
+++ b/internal/zkcert/generator.go
@@ -103,9 +103,6 @@ func (s *Service) AddZKCertToQueue(
 ) {
 	s.taskQueue.Add(tq.NewTask(
 		func() (zkcertificate.IssuedCertificate[zkcertificate.KYCContent], error) {
-			// This is to give the merkle proof service time to "see" the latest merkle proof root
-			time.Sleep(3 * time.Second)
-
 			_, issuedCert, err := cmd.IssueZKCert(ctx, certificate, s.EthClient, s.merkleProofClient, s.registryAddress, s.providerKey)
 			if err != nil {
 				log.WithError(err).Error("issue zk certificate")


### PR DESCRIPTION
This PR introduces improvements to the certificate issuance process and updates the dependency on guardians-sdk:

1. Update guardians-sdk to [v1.10.1](https://github.com/Galactica-corp/guardians-sdk/releases/tag/v1.10.0):
  - Eliminates the need for extra waiting time for the merkle proof service
  - Enhances smart-contract queue protection against submitting different certificates with the same human ID using different holder commitments
2. Improve error handling and cleanup in case of certificate issuance failure

These changes enhance the reliability and efficiency of the certificate issuance process while maintaining security measures provided by the updated guardians-sdk.