### PR TITLE
Update Guardians SDK to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/biter777/countries v1.7.5
 	github.com/dgraph-io/badger/v4 v4.2.0
 	github.com/ethereum/go-ethereum v1.14.8
-	github.com/galactica-corp/guardians-sdk v1.10.1
+	github.com/galactica-corp/guardians-sdk v1.11.0
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/iden3/go-iden3-crypto v0.0.16
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nos
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
-github.com/galactica-corp/guardians-sdk v1.10.1 h1:hdzulQIeav5Y37PCLaRXTnaUG1S4aIcLGNo69l/t/84=
-github.com/galactica-corp/guardians-sdk v1.10.1/go.mod h1:7PZ7QwUCGj3YEdjAWfyqXrXZaPDdMvOzDiaQTl+9mzo=
+github.com/galactica-corp/guardians-sdk v1.11.0 h1:di3pBJXekclDhS5a/ZZ8H2R5bvmtTJYqpOl7jgYo1+I=
+github.com/galactica-corp/guardians-sdk v1.11.0/go.mod h1:7PZ7QwUCGj3YEdjAWfyqXrXZaPDdMvOzDiaQTl+9mzo=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getsentry/sentry-go v0.27.0 h1:Pv98CIbtB3LkMWmXi4Joa5OOcwbmnX88sF5qbK3r3Ps=


### PR DESCRIPTION
Guardians SDK in the version [v1.11.0](https://github.com/Galactica-corp/guardians-sdk/releases/tag/v1.11.0) has a fix that allows using derived issuing keys. Details are in this PR: https://github.com/Galactica-corp/guardians-sdk/pull/17.

The fix is completely internal, and doesn't require to change the calling code.