### PR TITLE
Return 404 instead of 500 when cert is not found

### DIFF
--- a/internal/api/errs.go
+++ b/internal/api/errs.go
@@ -9,6 +9,7 @@ var (
 	ErrParsDate           = fmt.Errorf("parsing profile date failed")
 	ErrParsNationality    = fmt.Errorf("parsing profile nationality failed")
 	ErrCertGenerating     = fmt.Errorf("generating cert failed")
+	ErrCertNotFound       = fmt.Errorf("certificate not found")
 	ErrReadCertStatus     = fmt.Errorf("reading cert status failed")
 	ErrAddCertToQueue     = fmt.Errorf("adding cert to queue failed")
 	ErrAddCertToDB        = fmt.Errorf("adding cert to DB failed")

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -189,6 +189,14 @@ func (h *Handlers) GetCert(c echo.Context) error {
 		Info("request")
 
 	certificate, err := readCertFromDB(h.inMem, req.UserID)
+
+	if err == ErrCertNotFound {
+		log.WithError(err).Error(ErrCertNotFound)
+		return c.JSON(http.StatusNotFound, ErrorResp{
+			Error: fmt.Sprintf("%v: %v", ErrCertNotFound, err),
+		})
+	}
+
 	if err != nil {
 		log.WithError(err).Error(ErrReadCertStatus)
 		return c.JSON(http.StatusInternalServerError, ErrorResp{

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -25,7 +25,7 @@ func readCertFromDB(db *badger.DB, userID UserID) (string, error) {
 	err := db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(userID))
 		if err == badger.ErrKeyNotFound {
-			return fmt.Errorf("certificate not found")
+			return ErrCertNotFound
 		}
 		if err != nil {
 			return fmt.Errorf("error retrieving certificate: %w", err)


### PR DESCRIPTION
Not sure if this is the best way to do it, but the idea is to return 404 instead of 500 when the `readCertFromDB` db call does not find a cert. Currently it returns 500 whatever the error, which is resulting in heavy alerting on our side. Using 404 will enable us to treat it as normal execution.